### PR TITLE
Fix serializing when path has integer bits

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -113,34 +113,34 @@ class Json
     /**
      * Appends the given value to an array of data on the path to serializing to a JSON string
      */
-    public function appendValue(object $data, $value)
+    public function appendValue(array &$data, $value)
     {
         if ($this->omit_empty && $this->isEmpty($value)) {
             return;
         }
         $max = count($this->path)-1;
-        $d = $data;
+        $d = &$data;
         foreach ($this->path as $i => $pathBit) {
-            if (property_exists($d, $pathBit) && $i === $max) {
+            if (array_key_exists($pathBit, $d) && $i === $max) {
                 throw new \Exception('invalid path: '.json_encode($this->path));
             }
 
-            if (!property_exists($d, $pathBit) && $i < $max) {
-                $d->$pathBit = new stdClass;
+            if (!array_key_exists($pathBit, $d) && $i < $max) {
+                $d[$pathBit] = [];
             }
 
             if ($i < $max) {
-                $d = $data->$pathBit;
+                $d = &$d[$pathBit];
             }
 
             if ($i === $max) {
                 if (is_array($value)) {
-                    $d->$pathBit = [];
+                    $d[$pathBit] = [];
                     foreach ($value as $k => $val) {
-                        $d->$pathBit[$k] = $this->jsonValue($val);
+                        $d[$pathBit][$k] = $this->jsonValue($val);
                     }
                 } else {
-                    $d->$pathBit = $this->jsonValue($value);
+                    $d[$pathBit] = $this->jsonValue($value);
                 }
             }
         }

--- a/src/JsonSerialize.php
+++ b/src/JsonSerialize.php
@@ -19,7 +19,7 @@ trait JsonSerialize
     {
         $r = RClass::make($this);
         $props = $r->getProperties();
-        $d = new stdClass;
+        $d = [];
         foreach ($props as $prop) {
             $attrs = $prop->getAttributes(Json::class, ReflectionAttribute::IS_INSTANCEOF);
             if (empty($attrs)) {

--- a/tests/DeSerializationTest.php
+++ b/tests/DeSerializationTest.php
@@ -475,4 +475,3 @@ final class DeSerializationTest extends TestCase
         ], $this->export($dl));
     }
 }
-

--- a/tests/DeSerializationTest.php
+++ b/tests/DeSerializationTest.php
@@ -3,12 +3,15 @@ namespace Square\Pjson\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Square\Pjson\Json;
+use Square\Pjson\JsonSerialize;
 use Square\Pjson\Tests\Definitions\BigCat;
 use Square\Pjson\Tests\Definitions\BigInt;
 use Square\Pjson\Tests\Definitions\CatalogCategory;
 use Square\Pjson\Tests\Definitions\CatalogItem;
 use Square\Pjson\Tests\Definitions\CatalogObject;
 use Square\Pjson\Tests\Definitions\Category;
+use Square\Pjson\Tests\Definitions\MenuList;
 use Square\Pjson\Tests\Definitions\Schedule;
 use Square\Pjson\Tests\Definitions\Privateer;
 use Square\Pjson\Tests\Definitions\Stats;
@@ -454,4 +457,22 @@ final class DeSerializationTest extends TestCase
             ]
         ], $this->export($stats));
     }
+
+    public function testIntegerPath()
+    {
+        $json = '{
+            "menus": [
+                {"main": true, "name": "main-menu"},
+                {"main": false, "name": "secondary-menu"}
+            ]
+        }';
+
+        $dl = MenuList::fromJsonString($json);
+
+        $this->assertEquals([
+            "@class" => MenuList::class,
+            "mainMenuName" => "main-menu"
+        ], $this->export($dl));
+    }
 }
+

--- a/tests/Definitions/MenuList.php
+++ b/tests/Definitions/MenuList.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Square\Pjson\Tests\Definitions;
+
+use Square\Pjson\Json;
+use Square\Pjson\JsonSerialize;
+
+class MenuList
+{
+    use JsonSerialize;
+
+    #[Json(['menus', 0, 'name'])]
+    public string $mainMenuName;
+}

--- a/tests/SerializationTest.php
+++ b/tests/SerializationTest.php
@@ -10,6 +10,7 @@ use Square\Pjson\Tests\Definitions\CatalogCategory;
 use Square\Pjson\Tests\Definitions\CatalogItem;
 use Square\Pjson\Tests\Definitions\CatalogObject;
 use Square\Pjson\Tests\Definitions\Category;
+use Square\Pjson\Tests\Definitions\MenuList;
 use Square\Pjson\Tests\Definitions\Privateer;
 use Square\Pjson\Tests\Definitions\Schedule;
 use Square\Pjson\Tests\Definitions\Stats;
@@ -225,5 +226,21 @@ final class SerializationTest extends TestCase
             '{"count":"123456789876543234567898765432345678976543234567876543212345678765432"}',
             $stats->toJson()
         );
+    }
+
+    public function testIntegerPath()
+    {
+        $json = '{
+            "menus": [
+                {"main": true, "name": "main-menu"},
+                {"main": false, "name": "secondary-menu"}
+            ]
+        }';
+
+        $dl = MenuList::fromJsonString($json);
+
+        // MenuList doesn't store the entire structure. Only the name of the first menu
+        // it can however still output all the data it has back into its original shape
+        $this->assertEquals('{"menus":[{"name":"main-menu"}]}', $dl->toJson());
     }
 }


### PR DESCRIPTION
Deserializing `#[Json('list', 0, 'name')]` was already fine but the issue
was when re-serializing this.

Using `stdClass` meant it was impossible to set something at the property
`0`. By switching internally to an `array`, we can add properties and / or
integer offsets correctly.

@mattgrande @bezhermoso @szainmehdi 