### PR TITLE
Add option to mark properties as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,22 @@ $w->size = Size::BIG;
 $w->toJson(); // {"status": "big"}
 ```
 
+### Required properties
+You can mark a property as required for deserialization:
+```php
+readonly class Token
+{
+    use JsonSerialize;
+
+    #[Json(required: true)]
+    public string $key;
+}
+
+$token = Token::fromJsonString('{"key":"data"}'); // successful
+
+Token::fromJsonString('{"other":"has no key"}'); // throws Exception
+```
+
 ### Scalar <=> Class
 In some cases, you might want a scalar value to become a PHP object once deserialized and vice-versa. For example, a `BigInt` class
 could hold an int as a string and represent it as a string when serialized to JSON:

--- a/src/Json.php
+++ b/src/Json.php
@@ -18,11 +18,14 @@ class Json
 
     protected string $collection_factory_method;
 
+    protected bool $required;
+
     public function __construct(
         string|array $path = '',
         string $type = '',
         bool $omit_empty = false,
-        string $collection_factory_method = ''
+        string $collection_factory_method = '',
+        bool $required = false,
     ) {
         if ($path !== '') {
             if (is_string($path)) {
@@ -37,6 +40,7 @@ class Json
 
         $this->omit_empty = $omit_empty;
         $this->collection_factory_method = $collection_factory_method;
+        $this->required = $required;
     }
 
     /**
@@ -60,7 +64,7 @@ class Json
     {
         foreach ($this->path as $pathBit) {
             if (!array_key_exists($pathBit, $data)) {
-                return ;
+                return $this->handleMissingValue();
             }
             $data = $data[$pathBit];
         }
@@ -110,6 +114,17 @@ class Json
         }
 
         return $data;
+    }
+
+    /**
+     * What happens when deserializing a property that isn't set.
+     */
+    protected function handleMissingValue()
+    {
+        if ($this->required) {
+            throw new \Exception('missing required value: '.json_encode($this->path));
+        }
+        return null;
     }
 
     protected function isCollection(string $className)

--- a/tests/DeSerializationTest.php
+++ b/tests/DeSerializationTest.php
@@ -14,6 +14,7 @@ use Square\Pjson\Tests\Definitions\Collector;
 use Square\Pjson\Tests\Definitions\MenuList;
 use Square\Pjson\Tests\Definitions\Schedule;
 use Square\Pjson\Tests\Definitions\Privateer;
+use Square\Pjson\Tests\Definitions\Token;
 use Square\Pjson\Tests\Definitions\Stats;
 use Square\Pjson\Tests\Definitions\Traitor;
 use Square\Pjson\Tests\Definitions\Weekend;
@@ -533,5 +534,28 @@ final class DeSerializationTest extends TestCase
             "factoried_schedules" => $collectionStructure,
             "static_factoried_schedules" => $collectionStructure,
         ], $this->export($data));
+    }
+
+    public function testRequiredProperty()
+    {
+        $json = '{
+            "key": "my_key"
+        }';
+
+        $token = Token::fromJsonString($json);
+
+        $this->assertEquals([
+            "@class" => Token::class,
+            "key" => "my_key",
+        ], $this->export($token));
+    }
+
+    public function testRequiredPropertyMissing()
+    {
+        $json = '{}';
+
+        $this->expectException(\Exception::class);
+
+        Token::fromJsonString($json);
     }
 }

--- a/tests/Definitions/Token.php
+++ b/tests/Definitions/Token.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Square\Pjson\Tests\Definitions;
+
+use Square\Pjson\Json;
+use Square\Pjson\JsonSerialize;
+
+class Token
+{
+    use JsonSerialize;
+
+    #[Json(required: true)]
+    public string $key;
+}


### PR DESCRIPTION
This will then throw an exception while deserializing if the JSON data does not contain the property at all instead of keeping it uninitialized.