### PR TITLE
Handle nullable object arrays

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -73,7 +73,7 @@ class Json
         }
 
         if (!class_exists($typename) && $typename === 'array' && isset($this->type)) {
-            return array_map(fn ($d) => $this->type::fromJsonData($d), $data);
+            return is_null($data) ? $data : array_map(fn ($d) => $this->type::fromJsonData($d), $data);
         }
 
         if (RClass::make($typename)->readsFromJson()) {

--- a/tests/DeSerializationTest.php
+++ b/tests/DeSerializationTest.php
@@ -62,6 +62,7 @@ final class DeSerializationTest extends TestCase
             "data_name" => null,
             "schedule" => null,
             "schedules" => null,
+            "nullableSchedules" => null,
             "counts" => [],
             "unnamed" => null,
             "untypedSchedule" => null,
@@ -87,6 +88,7 @@ final class DeSerializationTest extends TestCase
             "name" => "Clothes",
             "schedule" => null,
             "schedules" => null,
+            "nullableSchedules" => null,
             "counts" => [],
             "unnamed" => null,
             "untypedSchedule" => null,
@@ -127,6 +129,7 @@ final class DeSerializationTest extends TestCase
               "end" => 20,
             ],
             "schedules" => null,
+            "nullableSchedules" => null,
             "counts" => [],
             "unnamed" => null,
             "untypedSchedule" => null,
@@ -154,7 +157,8 @@ final class DeSerializationTest extends TestCase
                     "schedule_start": 30,
                     "schedule_end": 40
                 }
-            ]
+            ],
+            "nullable_schedules": null
         }');
         $this->assertEquals([
             '@class' => Category::class,
@@ -178,6 +182,7 @@ final class DeSerializationTest extends TestCase
                 "end" => 40,
               ],
             ],
+            "nullableSchedules" => null,
             "counts" => [],
             "unnamed" => null,
             "untypedSchedule" => null,
@@ -205,6 +210,7 @@ final class DeSerializationTest extends TestCase
             "data_name" => null,
             "schedule" => null,
             "schedules" => null,
+            "nullableSchedules" => null,
             "counts" => [
               0 => 1,
               1 => "abc",
@@ -233,6 +239,7 @@ final class DeSerializationTest extends TestCase
             "data_name" => null,
             "schedule" => null,
             "schedules" => null,
+            "nullableSchedules" => null,
             "counts" => [],
             "unnamed" => "bob",
             "untypedSchedule" => null,
@@ -261,6 +268,7 @@ final class DeSerializationTest extends TestCase
             "data_name" => null,
             "schedule" => null,
             "schedules" => null,
+            "nullableSchedules" => null,
             "counts" => [],
             "unnamed" => "bob",
             "untypedSchedule" => [

--- a/tests/Definitions/Category.php
+++ b/tests/Definitions/Category.php
@@ -28,6 +28,9 @@ class Category
     #[Json('upcomming_schedules', type: Schedule::class)]
     protected array $schedules;
 
+    #[Json('nullable_schedules', type: Schedule::class)]
+    protected ?array $nullableSchedules;
+
     #[Json('counts', omit_empty: true)]
     public array $counts = [];
 
@@ -48,5 +51,10 @@ class Category
     public function setUpcoming(array $up)
     {
         $this->schedules = $up;
+    }
+
+    public function setNullable()
+    {
+        $this->nullableSchedules = null;
     }
 }

--- a/tests/SerializationTest.php
+++ b/tests/SerializationTest.php
@@ -94,6 +94,7 @@ final class SerializationTest extends TestCase
         $c = new Category;
         $c->setSchedule(new Schedule(1, 20));
         $c->setUpcoming([new Schedule(1, 20), new Schedule(30, 40)]);
+        $c->setNullable();
         $this->assertEquals(json_encode(json_decode('{
             "identifier": "myid",
             "category_name": "Clothes",
@@ -113,7 +114,8 @@ final class SerializationTest extends TestCase
                     "schedule_start": 30,
                     "schedule_end": 40
                 }
-            ]
+            ],
+            "nullable_schedules": null
         }')), $c->toJson());
     }
 


### PR DESCRIPTION
If a JSON payload contains a property that can be `array|null` the current functionality breaks when attempting to pass a `null` value to `array_map` in `Json.php` line 76.

A `null` check has been added so that if the value from the JSON payload is `null` it returns the `null` value, otherwise it processes the value as normal.

In the example below an error would have previously been thrown:
INPUT:
```json
{
    "nullable_schedules": null
}
```
CLASS:
```php
class Category
{
    use JsonSerialize;

    #[Json('nullable_schedules', type: Schedule::class)]
    protected ?array $nullableSchedules;
}
```
ERROR:
`Fatal error: Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, null given`