### PR TITLE
Added support for an array containing a backed enum type

### DIFF
--- a/src/Internal/RClass.php
+++ b/src/Internal/RClass.php
@@ -54,7 +54,7 @@ class RClass
 
     public function isBackedEnum(): bool
     {
-        return class_exists(BackedEnum::class) && $this->rc->implementsInterface(BackedEnum::class);
+        return interface_exists(BackedEnum::class) && $this->rc->implementsInterface(BackedEnum::class);
     }
 
     public function isEnum(): bool

--- a/src/Internal/RClass.php
+++ b/src/Internal/RClass.php
@@ -1,13 +1,15 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Square\Pjson\Internal;
 
 use BackedEnum;
 use ReflectionClass;
 use Square\Pjson\FromJsonData;
-use UnitEnum;
 use Square\Pjson\JsonSerialize;
 use Square\Pjson\ToJsonData;
+use UnitEnum;
 
 class RClass
 {
@@ -27,13 +29,13 @@ class RClass
         }
     }
 
-    public static function make($class) : RClass
+    public static function make($class): RClass
     {
         if (is_object($class)) {
             $class = get_class($class);
         }
 
-        if (!array_key_exists($class, self::$cache)) {
+        if (! array_key_exists($class, self::$cache)) {
             self::$cache[$class] = new self($class);
         }
 
@@ -45,37 +47,35 @@ class RClass
         return $this->props;
     }
 
-    public function source() : ReflectionClass
+    public function source(): ReflectionClass
     {
         return $this->rc;
     }
 
-    public function isBackedEnum() : bool
+    public function isBackedEnum(): bool
     {
-        return $this->rc->implementsInterface(BackedEnum::class);
+        return class_exists(BackedEnum::class) && $this->rc->implementsInterface(BackedEnum::class);
     }
 
-    public function isEnum() : bool
+    public function isEnum(): bool
     {
         return $this->rc->implementsInterface(UnitEnum::class);
     }
 
-    public function isSimpleEnum() : bool
+    public function isSimpleEnum(): bool
     {
-        return $this->isEnum() && !$this->isBackedEnum();
+        return $this->isEnum() && ! $this->isBackedEnum();
     }
 
-    public function isMethodStatic(string $methodName) : bool
+    public function isMethodStatic(string $methodName): bool
     {
         return $this->rc->getMethod($methodName)->isStatic();
     }
 
     /**
      * True if the type either implements the FromJsonData interface or directly uses the JsonSerialize trait
-     *
-     * @return boolean
      */
-    public function readsFromJson() : bool
+    public function readsFromJson(): bool
     {
         $traits = class_uses($this->rc->getName());
 
@@ -84,10 +84,8 @@ class RClass
 
     /**
      * True if the type either implements the ToJsonData interface or directly uses the JsonSerialize trait
-     *
-     * @return boolean
      */
-    public function writesToJson() : bool
+    public function writesToJson(): bool
     {
         $traits = class_uses($this->rc->getName());
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -88,7 +88,15 @@ class Json
             return $data;
         }
         if (!class_exists($typename) && $typename === 'array' && isset($this->type)) {
-            return is_null($data) ? $data : array_map(fn ($d) => $this->type::fromJsonData($d), $data);
+            if (is_null($data)) {
+                return $data;
+            }
+
+            if (RClass::make($this->type)->isBackedEnum()) {
+                return array_map(fn ($d) => $this->type::from($d), $data);
+            }
+
+            return array_map(fn ($d) => $this->type::fromJsonData($d), $data);
         }
 
         // Deal with collections / Traversable classes

--- a/tests/Definitions/StatusList.php
+++ b/tests/Definitions/StatusList.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Square\Pjson\Tests\Definitions;
+
+use Square\Pjson\Json;
+use Square\Pjson\JsonSerialize;
+
+class StatusList
+{
+    use JsonSerialize;
+
+    #[Json('status_list', type: Status::class)]
+    public array $statusList;
+}

--- a/tests/php81/Php81DeSerializationTest.php
+++ b/tests/php81/Php81DeSerializationTest.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 use Square\Pjson\Tests\Definitions\DTO;
 use Square\Pjson\Tests\Definitions\Size;
 use Square\Pjson\Tests\Definitions\Status;
+use Square\Pjson\Tests\Definitions\StatusList;
 use Square\Pjson\Tests\Definitions\Widget;
 
 final class Php81DeSerializationTest extends TestCase
@@ -107,6 +108,33 @@ final class Php81DeSerializationTest extends TestCase
             "size" => [
                 '@class' => Size::class,
                 'name' => 'BIG',
+            ],
+        ], $this->export($w));
+    }
+
+    public function testBackedEnumArray()
+    {
+        $w = StatusList::fromJsonString('{
+            "status_list": ["ON", "OFF", "ON"]
+        }');
+        $this->assertEquals([
+            "@class" => StatusList::class,
+            "statusList" => [
+                0 => [
+                    "@class" => Status::class,
+                    "name" => "ON",
+                    "value" => "ON",
+                ],
+                1 => [
+                    "@class" => Status::class,
+                    "name" => "OFF",
+                    "value" => "OFF",
+                ],
+                2 => [
+                    "@class" => Status::class,
+                    "name" => "ON",
+                    "value" => "ON",
+                ]
             ],
         ], $this->export($w));
     }

--- a/tests/php81/Php81SerializationTest.php
+++ b/tests/php81/Php81SerializationTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 use Square\Pjson\Tests\Definitions\DTO;
 use Square\Pjson\Tests\Definitions\Size;
 use Square\Pjson\Tests\Definitions\Status;
+use Square\Pjson\Tests\Definitions\StatusList;
 use Square\Pjson\Tests\Definitions\Widget;
 
 final class Php81SerializationTest extends TestCase
@@ -34,6 +35,15 @@ final class Php81SerializationTest extends TestCase
         $this->assertEquals(json_encode(json_decode('{
             "status": "ON",
             "size": "big"
+        }')), $w->toJson());
+    }
+
+    public function testBackedEnumArray()
+    {
+        $w = new StatusList();
+        $w->statusList = [Status::ON, Status::OFF, Status::ON];
+        $this->assertEquals(json_encode(json_decode('{
+            "status_list": ["ON", "OFF", "ON"]
         }')), $w->toJson());
     }
 }


### PR DESCRIPTION
Hi, this change allows lists of backed enums without having to implement fromJsonData() on the enum.

Given the following enum:
```php
enum Status : string
{
    case ON = 'ON';
    case OFF = 'OFF';
}
```

And the following property:
```php
 #[Json('status_list', type: Status::class)]
 public array $statusList;
```

A json document like the following would return 3 Status enums:
```json
{"status_list": ["ON", "OFF", "ON"]}
```