### PR TITLE
Handle null data when retrieving value

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -70,18 +70,17 @@ class Json
     public function retrieveValue(?array $data, ReflectionNamedType|ReflectionUnionType|null $type = null)
     {
         foreach ($this->path as $pathBit) {
-            if (! array_key_exists($pathBit, $data)) {
+            if (is_null($data) || ! array_key_exists($pathBit, $data)) {
                 return $this->handleMissingValue($data);
             }
             $data = $data[$pathBit];
         }
+        if (is_null($data)) {
+            return null;
+        }
 
         if ($type instanceof ReflectionUnionType) {
             $type = RUnionType::getSingleTypeMatch($type, $data);
-        }
-
-        if (is_null($data) && $type && $type->allowsNull()) {
-            return null;
         }
 
         if ($type === null) {
@@ -100,10 +99,6 @@ class Json
             return $data;
         }
         if (! class_exists($typename) && $typename === 'array' && isset($this->type)) {
-            if (is_null($data)) {
-                return $data;
-            }
-
             if (RClass::make($this->type)->isBackedEnum()) {
                 return array_map(fn ($d) => $this->type::from($d), $data);
             }

--- a/tests/DeSerializationTest.php
+++ b/tests/DeSerializationTest.php
@@ -32,7 +32,7 @@ final class DeSerializationTest extends TestCase
 
     const UNINITIALIZED = '@uninitialized';
     
-    function export($value)
+    public function export($value)
     {
         if (is_null($value)) {
             return $value;

--- a/tests/DeSerializationTest.php
+++ b/tests/DeSerializationTest.php
@@ -681,9 +681,9 @@ final class DeSerializationTest extends TestCase
         $c = Category::fromJsonString('{"next_schedule": null}');
         $this->assertEquals([
             '@class' => Category::class,
-            'id' => null, 
-            'name' => null, 
-            'data_name' => null, 
+            'id' => null,
+            'name' => null,
+            'data_name' => null,
             'schedule' =>  self::UNINITIALIZED, // should stay uninitialized because it's a non-nullable field
             'nullableSchedule' => null,
             'schedules' => self::UNINITIALIZED,

--- a/tests/DeSerializationTest.php
+++ b/tests/DeSerializationTest.php
@@ -29,7 +29,10 @@ use Square\Pjson\Tests\Definitions\Weekend;
 
 final class DeSerializationTest extends TestCase
 {
-    public function export($value)
+
+    const UNINITIALIZED = '@uninitialized';
+    
+    function export($value)
     {
         if (is_null($value)) {
             return $value;
@@ -53,7 +56,7 @@ final class DeSerializationTest extends TestCase
         ];
         foreach ($rc->getProperties() as $prop) {
             $prop->setAccessible(true);
-            $v = $prop->isInitialized($value) ? $prop->getValue($value) : null;
+            $v = $prop->isInitialized($value) ? $prop->getValue($value) : self::UNINITIALIZED;
             $n = $prop->getName();
 
             $data[$n] = $this->export($v);
@@ -70,12 +73,12 @@ final class DeSerializationTest extends TestCase
             'id' => 'myid',
             'name' => 'Clothes',
             'data_name' => null,
-            'schedule' => null,
+            'schedule' => self::UNINITIALIZED,
             'nullableSchedule' => null,
-            'schedules' => null,
+            'schedules' => self::UNINITIALIZED,
             'nullableSchedules' => null,
             'counts' => [],
-            'unnamed' => null,
+            'unnamed' => self::UNINITIALIZED,
             'untypedSchedule' => null,
         ], $this->export($c));
     }
@@ -95,12 +98,12 @@ final class DeSerializationTest extends TestCase
             'id' => 'myid',
             'name' => 'Clothes',
             'data_name' => null,
-            'schedule' => null,
+            'schedule' => self::UNINITIALIZED,
             'nullableSchedule' => null,
-            'schedules' => null,
+            'schedules' => self::UNINITIALIZED,
             'nullableSchedules' => null,
             'counts' => [],
-            'unnamed' => null,
+            'unnamed' => self::UNINITIALIZED,
             'untypedSchedule' => null,
         ], $this->export($c));
         $this->assertNull($c->nullableSchedule);
@@ -123,12 +126,12 @@ final class DeSerializationTest extends TestCase
             'data_name' => null,
             'id' => 'myid',
             'name' => 'Clothes',
-            'schedule' => null,
+            'schedule' => self::UNINITIALIZED,
             'nullableSchedule' => null,
-            'schedules' => null,
+            'schedules' => self::UNINITIALIZED,
             'nullableSchedules' => null,
             'counts' => [],
-            'unnamed' => null,
+            'unnamed' => self::UNINITIALIZED,
             'untypedSchedule' => null,
         ], $this->export($bc));
     }
@@ -167,10 +170,10 @@ final class DeSerializationTest extends TestCase
                 'end' => 20,
             ],
             'nullableSchedule' => null,
-            'schedules' => null,
+            'schedules' => self::UNINITIALIZED,
             'nullableSchedules' => null,
             'counts' => [],
-            'unnamed' => null,
+            'unnamed' => self::UNINITIALIZED,
             'untypedSchedule' => null,
         ], $this->export($c));
     }
@@ -224,7 +227,7 @@ final class DeSerializationTest extends TestCase
             ],
             'nullableSchedules' => null,
             'counts' => [],
-            'unnamed' => null,
+            'unnamed' => self::UNINITIALIZED,
             'untypedSchedule' => null,
         ], $this->export($c));
     }
@@ -248,16 +251,16 @@ final class DeSerializationTest extends TestCase
             'id' => 'myid',
             'name' => 'Clothes',
             'data_name' => null,
-            'schedule' => null,
+            'schedule' => self::UNINITIALIZED,
             'nullableSchedule' => null,
-            'schedules' => null,
+            'schedules' => self::UNINITIALIZED,
             'nullableSchedules' => null,
             'counts' => [
                 0 => 1,
                 1 => 'abc',
                 2 => 678,
             ],
-            'unnamed' => null,
+            'unnamed' => self::UNINITIALIZED,
             'untypedSchedule' => null,
         ], $this->export($c));
     }
@@ -278,9 +281,9 @@ final class DeSerializationTest extends TestCase
             'id' => 'myid',
             'name' => 'Clothes',
             'data_name' => null,
-            'schedule' => null,
+            'schedule' => self::UNINITIALIZED,
             'nullableSchedule' => null,
-            'schedules' => null,
+            'schedules' => self::UNINITIALIZED,
             'nullableSchedules' => null,
             'counts' => [],
             'unnamed' => 'bob',
@@ -308,9 +311,9 @@ final class DeSerializationTest extends TestCase
             'id' => 'myid',
             'name' => 'Clothes',
             'data_name' => null,
-            'schedule' => null,
+            'schedule' => self::UNINITIALIZED,
             'nullableSchedule' => null,
-            'schedules' => null,
+            'schedules' => self::UNINITIALIZED,
             'nullableSchedules' => null,
             'counts' => [],
             'unnamed' => 'bob',

--- a/tests/DeSerializationTest.php
+++ b/tests/DeSerializationTest.php
@@ -675,4 +675,40 @@ final class DeSerializationTest extends TestCase
             ],
         ]);
     }
+
+    public function testNonNullableFieldWithNullValue()
+    {
+        $c = Category::fromJsonString('{"next_schedule": null}');
+        $this->assertEquals([
+            '@class' => Category::class,
+            'id' => null, 
+            'name' => null, 
+            'data_name' => null, 
+            'schedule' =>  self::UNINITIALIZED, // should stay uninitialized because it's a non-nullable field
+            'nullableSchedule' => null,
+            'schedules' => self::UNINITIALIZED,
+            'nullableSchedules' => null,
+            'counts' => [],
+            'unnamed' => self::UNINITIALIZED,
+            'untypedSchedule' => null,
+        ], $this->export($c));
+    }
+
+    public function testNullParentObjectForNestedPath()
+    {
+        $c = Category::fromJsonString('{"data": null}');
+        $this->assertEquals([
+            '@class' => Category::class,
+            'id' => null,
+            'name' => null,
+            'data_name' => null, // set to null because the parent object is null and it can be null
+            'schedule' =>  self::UNINITIALIZED,
+            'nullableSchedule' => null,
+            'schedules' => self::UNINITIALIZED,
+            'nullableSchedules' => null,
+            'counts' => [],
+            'unnamed' => self::UNINITIALIZED,
+            'untypedSchedule' => null,
+        ], $this->export($c));
+    }
 }

--- a/tests/php81/Php81DeSerializationTest.php
+++ b/tests/php81/Php81DeSerializationTest.php
@@ -11,6 +11,8 @@ use Square\Pjson\Tests\Definitions\Widget;
 
 final class Php81DeSerializationTest extends TestCase
 {
+    const UNINITIALIZED = '@uninitialized';
+
     public function export($value)
     {
         if (is_null($value)) {
@@ -33,7 +35,7 @@ final class Php81DeSerializationTest extends TestCase
             '@class' => get_class($value),
         ];
         foreach ($rc->getProperties() as $prop) {
-            $v = $prop->isInitialized($value) ? $prop->getValue($value) : '@uninitialized';
+            $v = $prop->isInitialized($value) ? $prop->getValue($value) : self::UNINITIALIZED;
             $n = $prop->getName();
 
             $data[$n] = $this->export($v);
@@ -67,7 +69,7 @@ final class Php81DeSerializationTest extends TestCase
               "value" => "ON",
             ],
             "optional" => null,
-            "size" => '@uninitialized',
+            "size" => self::UNINITIALIZED,
         ], $this->export($w));
     }
 


### PR DESCRIPTION
## [Issue]

During deserialization, in some cases the following error gets thrown:
```
array_key_exists(): Argument #2 ($array) must be of type array, null given
#0 /var/www/vendor/square/pjson/src/Json.php(67): array_key_exists(string(length=9), NULL)
#1 /var/www/vendor/square/pjson/src/JsonSerialize.php(100): Square\Pjson\Json->retrieveValue(NULL,object(ReflectionNamedType))
...
```

This is because `retrieveValue` accepts `?array` but `array_key_exists` does not.

Scenarios where I've seen this occur:
- The model field is defined as non-nullable AND it requires internal deserialization itself but the data received for that field is `null
     - So if the field is `string $foo` and we receive `"foo": null` then it will stay uninitialized currently
     - But if the field is `Category $foo` and `Category` has `#[Json]` annotated fields then this error will get thrown
     - This fixes the library behaviour to treat both scenarios the same. i.e. the field will stay uninitialized 
    
- In the case of nested property paths, if any of the containing fields are null
    - For example, if the received JSON has `data:null` for the below:
    ```
    #[Json(["data", "name"])]
    protected $data_name;
    ```

## [Fix]

- Do null checks while traversing the `$pathBits` to the field inside `retrieveValue`
- After arriving at the field, modify the null checking afterwards to _immediately_ return if the final field is `null`.
    - The caller [JsonSerialize::fromJsonData](https://github.com/square/pjson/blob/main/src/JsonSerialize.php#L101-L105) has the necessary logic to deal with the returned null. Namely, if the type allows null, set the field. If not, leave it uninitialized

## [Tests]
Added tests to demonstrate the fix.

Prior to the fix:
```
1) Square\Pjson\Tests\DeSerializationTest::testNonNullableFieldWithNullValue
TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given

/Users/jboudreau/Development/pjson/src/Json.php:73
/Users/jboudreau/Development/pjson/src/JsonSerialize.php:101
/Users/jboudreau/Development/pjson/src/Json.php:132
/Users/jboudreau/Development/pjson/src/JsonSerialize.php:101
/Users/jboudreau/Development/pjson/src/JsonSerialize.php:55
/Users/jboudreau/Development/pjson/tests/DeSerializationTest.php:717

2) Square\Pjson\Tests\DeSerializationTest::testNullParentObjectForNestedPath
TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given

/Users/jboudreau/Development/pjson/src/Json.php:73
/Users/jboudreau/Development/pjson/src/JsonSerialize.php:101
/Users/jboudreau/Development/pjson/src/JsonSerialize.php:55
/Users/jboudreau/Development/pjson/tests/DeSerializationTest.php:735
```
