### PR TITLE
Fix php8.5 deprecated setAccessible calls

### DIFF
--- a/src/Internal/RClass.php
+++ b/src/Internal/RClass.php
@@ -23,10 +23,6 @@ class RClass
     {
         $this->rc = new ReflectionClass($class);
         $this->props = $this->rc->getProperties();
-
-        foreach ($this->props as $prop) {
-            $prop->setAccessible(true);
-        }
     }
 
     public static function make($class): RClass

--- a/tests/DeSerializationTest.php
+++ b/tests/DeSerializationTest.php
@@ -56,7 +56,6 @@ final class DeSerializationTest extends TestCase
             '@class' => get_class($value),
         ];
         foreach ($rc->getProperties() as $prop) {
-            $prop->setAccessible(true);
             $v = $prop->isInitialized($value) ? $prop->getValue($value) : self::UNINITIALIZED;
             $n = $prop->getName();
 


### PR DESCRIPTION
These functions raise deprecation notices in 8.5 and are no-ops since 8.1.